### PR TITLE
feat: Add taskdefinition to ecs tasks and env vars command

### DIFF
--- a/aws/ecs-tasks_test.go
+++ b/aws/ecs-tasks_test.go
@@ -23,7 +23,6 @@ func TestECSTasks(t *testing.T) {
 			outputDirectory: ".",
 			verbosity:       2,
 			testModule: ECSTasksModule{
-
 				AWSProfile:     "default",
 				AWSRegions:     []string{"us-east-1", "us-west-1"},
 				Caller:         sts.GetCallerIdentityOutput{Arn: aws.String("arn:aws:iam::123456789012:user/cloudfox_unit_tests")},
@@ -33,10 +32,11 @@ func TestECSTasks(t *testing.T) {
 				ECSClient:      &sdk.MockedECSClient{},
 			},
 			expectedResult: []MappedECSTask{{
-				Cluster:    "MyCluster",
-				ID:         "74de0355a10a4f979ac495c14EXAMPLE",
-				ExternalIP: "203.0.113.12",
-				Role:       "test123",
+				Cluster:       "MyCluster",
+				ID:            "74de0355a10a4f979ac495c14EXAMPLE",
+				ContainerName: "web",
+				ExternalIP:    "203.0.113.12",
+				Role:          "test123",
 			}},
 		},
 	}
@@ -47,6 +47,9 @@ func TestECSTasks(t *testing.T) {
 			for index, expectedTask := range subtest.expectedResult {
 				if expectedTask.Cluster != subtest.testModule.MappedECSTasks[index].Cluster {
 					log.Fatal("Cluster name does not match expected value")
+				}
+				if expectedTask.ContainerName != subtest.testModule.MappedECSTasks[index].ContainerName {
+					log.Fatal("Container name does not match expected value")
 				}
 			}
 		})

--- a/aws/env-vars.go
+++ b/aws/env-vars.go
@@ -127,7 +127,6 @@ func (m *EnvsModule) PrintEnvs(outputDirectory string, verbosity int) {
 		"Account",
 		"Service",
 		"Region",
-		"TaskDefinition",
 		"Name",
 		"Key",
 		"Value",
@@ -150,7 +149,6 @@ func (m *EnvsModule) PrintEnvs(outputDirectory string, verbosity int) {
 			"Account",
 			"Service",
 			"Region",
-			"TaskDefinition",
 			"Name",
 			"Key",
 			"Value",
@@ -159,7 +157,6 @@ func (m *EnvsModule) PrintEnvs(outputDirectory string, verbosity int) {
 		tableCols = []string{
 			"Service",
 			"Region",
-			"TaskDefinition",
 			"Name",
 			"Key",
 			"Value",
@@ -170,14 +167,20 @@ func (m *EnvsModule) PrintEnvs(outputDirectory string, verbosity int) {
 	//Table rows
 	for _, envVar := range m.EnvironmentVariables {
 
+		var finalName string
+		if envVar.taskDefinition != "" {
+			finalName = fmt.Sprintf("%s/%s", envVar.name, envVar.taskDefinition)
+		} else {
+			finalName = envVar.name
+		}
+
 		if envVar.interesting {
 			m.output.Body = append(
 				m.output.Body, []string{
 					aws.ToString(m.Caller.Account),
 					envVar.service,
 					envVar.region,
-					envVar.taskDefinition,
-					envVar.name,
+					finalName,
 					magenta(envVar.environmentVarName),
 					magenta(envVar.environmentVarValue),
 				},
@@ -188,8 +191,7 @@ func (m *EnvsModule) PrintEnvs(outputDirectory string, verbosity int) {
 					aws.ToString(m.Caller.Account),
 					envVar.service,
 					envVar.region,
-					envVar.taskDefinition,
-					envVar.name,
+					finalName,
 					envVar.environmentVarName,
 					envVar.environmentVarValue,
 				},

--- a/aws/sdk/ecs_mocks.go
+++ b/aws/sdk/ecs_mocks.go
@@ -135,12 +135,30 @@ func (c *MockedECSClient) DescribeTasks(ctx context.Context, input *ecs.Describe
 							Status:  aws.String(a.Status),
 						})
 					}
+
+					var containers []ecsTypes.Container
+
+					for _, container := range mockedTask.Containers {
+						containers = append(containers, ecsTypes.Container{
+							ContainerArn: aws.String(container.ContainerArn),
+							Cpu:          aws.String(container.CPU),
+							HealthStatus: ecsTypes.HealthStatus(container.HealthStatus),
+							Image:        aws.String(container.Image),
+							LastStatus:   aws.String(container.LastStatus),
+							Memory:       aws.String(container.Memory),
+							Name:         aws.String(container.Name),
+							RuntimeId:    aws.String(container.RuntimeID),
+							TaskArn:      aws.String(container.TaskArn),
+						})
+					}
+
 					tasks = append(tasks, ecsTypes.Task{
 						ClusterArn:        aws.String(mockedTask.ClusterArn),
 						TaskDefinitionArn: aws.String(mockedTask.TaskDefinitionArn),
 						LaunchType:        ecsTypes.LaunchType(*aws.String(mockedTask.LaunchType)),
 						TaskArn:           aws.String(mockedTask.TaskArn),
 						Attachments:       attachments,
+						Containers:        containers,
 					})
 				}
 			}

--- a/globals/utils.go
+++ b/globals/utils.go
@@ -4,4 +4,5 @@ const CLOUDFOX_USER_AGENT = "cloudfox"
 const CLOUDFOX_LOG_FILE_DIR_NAME = ".cloudfox"
 const CLOUDFOX_BASE_DIRECTORY = "cloudfox-output"
 const LOOT_DIRECTORY_NAME = "loot"
-const CLOUDFOX_VERSION = "1.15.0"
+const CLOUDFOX_VERSION = "1.16.0-prerelease"
+å


### PR DESCRIPTION
#### Card
https://github.com/BishopFox/cloudfox/issues/85 : Associate container to ECS task in env-vars or ecs-task definitions

#### Details
- Added container name column to ecs-tasks command
Unittests for ecs-tasks command still work
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/27dbae4f-544e-4e0f-b147-ae3bb17e60f2" />

- Added task definition column to env-vars command
env-vars example output
<img width="1606" alt="image" src="https://github.com/user-attachments/assets/eb38abf3-d612-4485-af60-48cb74fb9898" />


