### PR TITLE
feat: Add apigateway service to resource trusts command

### DIFF
--- a/aws/resource-trusts.go
+++ b/aws/resource-trusts.go
@@ -968,16 +968,14 @@ func (m *ResourceTrustsModule) getAPIGatewayPoliciesPerRegion(r string, wg *sync
 	}
 
 	for _, restAPI := range restAPIs {
-		var isPublic string
-		var statementSummaryInEnglish string
-		var isInteresting = "No"
 
 		if sdk.IsPublicApiGateway(&restAPI) {
-			isPublic = magenta("Yes")
-			isInteresting = magenta("Yes")
-		} else {
-			isPublic = "No"
+			continue
 		}
+
+		var isPublic = "No"
+		var statementSummaryInEnglish string
+		var isInteresting = "No"
 
 		if restAPI.Policy != nil && *restAPI.Policy != "" {
 

--- a/aws/resource-trusts_test.go
+++ b/aws/resource-trusts_test.go
@@ -46,6 +46,10 @@ func TestIsResourcePolicyInteresting(t *testing.T) {
 }
 
 func TestKMSResourceTrusts(t *testing.T) {
+
+	mockedKMSClient := &sdk.MockedKMSClient{}
+	var kmsClient sdk.KMSClientInterface = mockedKMSClient
+
 	testCases := []struct {
 		outputDirectory string
 		verbosity       int
@@ -56,8 +60,9 @@ func TestKMSResourceTrusts(t *testing.T) {
 			outputDirectory: ".",
 			verbosity:       2,
 			testModule: ResourceTrustsModule{
-				KMSClient:  &sdk.MockedKMSClient{},
-				AWSRegions: []string{"us-west-2"},
+				KMSClient:        &kmsClient,
+				APIGatewayClient: nil,
+				AWSRegions:       []string{"us-west-2"},
 				Caller: sts.GetCallerIdentityOutput{
 					Account: aws.String("123456789012"),
 					Arn:     aws.String("arn:aws:iam::123456789012:user/cloudfox_unit_tests"),
@@ -80,7 +85,62 @@ func TestKMSResourceTrusts(t *testing.T) {
 				t.Fatal("Resource name does not match expected value")
 			}
 			if expectedResource2.ARN != tc.testModule.Resources2[index].ARN {
-				t.Fatal("Resource ID does not match expected value")
+				t.Fatal("Resource ARN does not match expected value")
+			}
+		}
+	}
+}
+
+func TestAPIGatewayResourceTrusts(t *testing.T) {
+
+	mockedAPIGatewayClient := &sdk.MockedAWSAPIGatewayClient{}
+	var apiGatewayClient sdk.APIGatewayClientInterface = mockedAPIGatewayClient
+
+	testCases := []struct {
+		outputDirectory string
+		verbosity       int
+		testModule      ResourceTrustsModule
+		expectedResult  []Resource2
+	}{
+		{
+			outputDirectory: ".",
+			verbosity:       2,
+			testModule: ResourceTrustsModule{
+				KMSClient:        nil,
+				APIGatewayClient: &apiGatewayClient,
+				AWSRegions:       []string{"us-west-2"},
+				Caller: sts.GetCallerIdentityOutput{
+					Account: aws.String("123456789012"),
+					Arn:     aws.String("arn:aws:iam::123456789012:user/cloudfox_unit_tests"),
+				},
+				Goroutines: 30,
+			},
+			expectedResult: []Resource2{
+				{
+					Name:   "api1",
+					ARN:    "arn:aws:execute-api:us-west-2:123456789012:abcdefg/*",
+					Public: "No",
+				},
+				{
+					Name:   "api2",
+					ARN:    "arn:aws:execute-api:us-west-2:123456789012:qwerty/*",
+					Public: "Yes",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.testModule.PrintResources(tc.outputDirectory, tc.verbosity)
+		for index, expectedResource2 := range tc.expectedResult {
+			if expectedResource2.Name != tc.testModule.Resources2[index].Name {
+				t.Fatal("Resource name does not match expected value")
+			}
+			if expectedResource2.ARN != tc.testModule.Resources2[index].ARN {
+				t.Fatal("Resource ARN does not match expected value")
+			}
+			if expectedResource2.Public != tc.testModule.Resources2[index].Public {
+				t.Fatal("Resource Public does not match expected value")
 			}
 		}
 	}

--- a/aws/resource-trusts_test.go
+++ b/aws/resource-trusts_test.go
@@ -117,14 +117,10 @@ func TestAPIGatewayResourceTrusts(t *testing.T) {
 			},
 			expectedResult: []Resource2{
 				{
-					Name:   "api1",
-					ARN:    "arn:aws:execute-api:us-west-2:123456789012:abcdefg/*",
-					Public: "No",
-				},
-				{
-					Name:   "api2",
-					ARN:    "arn:aws:execute-api:us-west-2:123456789012:qwerty/*",
-					Public: "Yes",
+					Name:        "api1",
+					ARN:         "arn:aws:execute-api:us-west-2:123456789012:abcdefg/*",
+					Public:      "No",
+					Interesting: "Yes",
 				},
 			},
 		},
@@ -141,6 +137,9 @@ func TestAPIGatewayResourceTrusts(t *testing.T) {
 			}
 			if expectedResource2.Public != tc.testModule.Resources2[index].Public {
 				t.Fatal("Resource Public does not match expected value")
+			}
+			if expectedResource2.Interesting != tc.testModule.Resources2[index].Interesting {
+				t.Fatal("Resource Interesting does not match expected value")
 			}
 		}
 	}

--- a/aws/resource-trusts_test.go
+++ b/aws/resource-trusts_test.go
@@ -131,7 +131,7 @@ func TestAPIGatewayResourceTrusts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc.testModule.PrintResources(tc.outputDirectory, tc.verbosity)
+		tc.testModule.PrintResources(tc.outputDirectory, tc.verbosity, false)
 		for index, expectedResource2 := range tc.expectedResult {
 			if expectedResource2.Name != tc.testModule.Resources2[index].Name {
 				t.Fatal("Resource name does not match expected value")

--- a/aws/sdk/apigateway.go
+++ b/aws/sdk/apigateway.go
@@ -53,7 +53,17 @@ func init() {
 	gob.Register([]apiGatewayTypes.UsagePlanKey{})
 }
 
-// create a CachedApiGatewayGetRestAPIs function that accepts a client, account id, region. Make sure it handles caching, the region option and pagination
+func IsPublicApiGateway(ra *apiGatewayTypes.RestApi) bool {
+	for _, endpointType := range ra.EndpointConfiguration.Types {
+		if endpointType == apiGatewayTypes.EndpointTypeRegional || endpointType == apiGatewayTypes.EndpointTypeEdge {
+			return true
+		}
+	}
+
+	return false
+}
+
+// CachedApiGatewayGetRestAPIs function that accepts a client, account id, region. Make sure it handles caching, the region option and pagination
 func CachedApiGatewayGetRestAPIs(client APIGatewayClientInterface, accountID string, region string) ([]apiGatewayTypes.RestApi, error) {
 	var PaginationControl *string
 	var restAPIs []apiGatewayTypes.RestApi

--- a/aws/sdk/apigateway_mocks.go
+++ b/aws/sdk/apigateway_mocks.go
@@ -22,6 +22,7 @@ func (m *MockedAWSAPIGatewayClient) GetRestApis(ctx context.Context, input *apig
 						apiGatewayTypes.EndpointTypePrivate,
 					},
 				},
+				Policy: aws.String("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"execute-api:Invoke\",\"Resource\":\"arn:aws:execute-api:us-west-2:123456789012:abcdefg/*/*/*\"}]}"),
 			},
 			{
 				Id:   aws.String("qwerty"),

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"log"
@@ -635,7 +636,7 @@ func FindOrgMgmtAccountAndReorderAccounts(AWSProfiles []string, version string) 
 			cacheDirectory := filepath.Join(AWSOutputDirectory, "cached-data", "aws", ptr.ToString(caller.Account))
 			err = internal.LoadCacheFromGobFiles(cacheDirectory)
 			if err != nil {
-				if err == internal.ErrDirectoryDoesNotExist {
+				if errors.Is(err, internal.ErrDirectoryDoesNotExist) {
 					fmt.Printf("[%s][%s] No cache directory for %s. Skipping loading cached data.\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", version)), cyan(profile), ptr.ToString(caller.Account))
 				} else {
 					fmt.Printf("[%s][%s] No cache data for %s. Error: %v\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", version)), cyan(profile), ptr.ToString(caller.Account), err)
@@ -1614,29 +1615,33 @@ func runRAMCommand(cmd *cobra.Command, args []string) {
 
 func runResourceTrustsCommand(cmd *cobra.Command, args []string) {
 	for _, profile := range AWSProfiles {
-		var AWSConfig = internal.AWSConfigFileLoader(profile, cmd.Root().Version, AWSMFAToken)
-		caller, err := internal.AWSWhoami(profile, cmd.Root().Version, AWSMFAToken)
-		var KMSClient sdk.KMSClientInterface = kms.NewFromConfig(AWSConfig)
-		var APIGatewayClient sdk.APIGatewayClientInterface = apigateway.NewFromConfig(AWSConfig)
-
-		if err != nil {
-			continue
-		}
-		m := aws.ResourceTrustsModule{
-			KMSClient:          &KMSClient,
-			APIGatewayClient:   &APIGatewayClient,
-			Caller:             *caller,
-			AWSProfileProvided: profile,
-			Goroutines:         Goroutines,
-			AWSRegions:         internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			WrapTable:          AWSWrapTable,
-			CloudFoxVersion:    cmd.Root().Version,
-			AWSOutputType:      AWSOutputType,
-			AWSTableCols:       AWSTableCols,
-			AWSConfig:          AWSConfig,
-		}
-		m.PrintResources(AWSOutputDirectory, Verbosity, ResourceTrustsIncludeKms)
+		runResourceTrustsCommandWithProfile(cmd, args, profile)
 	}
+}
+
+func runResourceTrustsCommandWithProfile(cmd *cobra.Command, args []string, profile string) {
+	var AWSConfig = internal.AWSConfigFileLoader(profile, cmd.Root().Version, AWSMFAToken)
+	caller, err := internal.AWSWhoami(profile, cmd.Root().Version, AWSMFAToken)
+	var KMSClient sdk.KMSClientInterface = kms.NewFromConfig(AWSConfig)
+	var APIGatewayClient sdk.APIGatewayClientInterface = apigateway.NewFromConfig(AWSConfig)
+
+	if err != nil {
+		return
+	}
+	m := aws.ResourceTrustsModule{
+		KMSClient:          &KMSClient,
+		APIGatewayClient:   &APIGatewayClient,
+		Caller:             *caller,
+		AWSProfileProvided: profile,
+		Goroutines:         Goroutines,
+		AWSRegions:         internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+		WrapTable:          AWSWrapTable,
+		CloudFoxVersion:    cmd.Root().Version,
+		AWSOutputType:      AWSOutputType,
+		AWSTableCols:       AWSTableCols,
+		AWSConfig:          AWSConfig,
+	}
+	m.PrintResources(AWSOutputDirectory, Verbosity, ResourceTrustsIncludeKms)
 }
 
 func runRoleTrustCommand(cmd *cobra.Command, args []string) {
@@ -1903,7 +1908,6 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		sqsClient := sqs.NewFromConfig(AWSConfig)
 		ssmClient := ssm.NewFromConfig(AWSConfig)
 		stepFunctionClient := sfn.NewFromConfig(AWSConfig)
-		kmsClient := kms.NewFromConfig(AWSConfig)
 
 		fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("Getting a lay of the land, aka \"What regions is this account using?\""))
 		inventory2 := aws.Inventory2Module{
@@ -1946,14 +1950,13 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 			SQSClient:              sqsClient,
 			SSMClient:              ssmClient,
 			StepFunctionClient:     stepFunctionClient,
-
-			Caller:        *caller,
-			AWSRegions:    internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			AWSProfile:    profile,
-			Goroutines:    Goroutines,
-			WrapTable:     AWSWrapTable,
-			AWSOutputType: AWSOutputType,
-			AWSTableCols:  AWSTableCols,
+			Caller:                 *caller,
+			AWSRegions:             internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+			AWSProfile:             profile,
+			Goroutines:             Goroutines,
+			WrapTable:              AWSWrapTable,
+			AWSOutputType:          AWSOutputType,
+			AWSTableCols:           AWSTableCols,
 		}
 		inventory2.PrintInventoryPerRegion(AWSOutputDirectory, Verbosity)
 
@@ -1998,11 +2001,10 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		instances.Instances(InstancesFilter, AWSOutputDirectory, Verbosity)
 		route53 := aws.Route53Module{
 			Route53Client: route53Client,
-
-			Caller:     *caller,
-			AWSRegions: internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			AWSProfile: profile,
-			Goroutines: Goroutines,
+			Caller:        *caller,
+			AWSRegions:    internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+			AWSProfile:    profile,
+			Goroutines:    Goroutines,
 		}
 
 		lambdasMod := aws.LambdasModule{
@@ -2036,7 +2038,6 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		filesystems.PrintFilesystems(AWSOutputDirectory, Verbosity)
 
 		endpoints := aws.EndpointsModule{
-
 			EKSClient:          eksClient,
 			S3Client:           s3Client,
 			LambdaClient:       lambdaClient,
@@ -2052,14 +2053,13 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 			CloudfrontClient:   cloudfrontClient,
 			AppRunnerClient:    appRunnerClient,
 			LightsailClient:    lightsailClient,
-
-			Caller:        *caller,
-			AWSRegions:    internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			AWSProfile:    profile,
-			Goroutines:    Goroutines,
-			WrapTable:     AWSWrapTable,
-			AWSOutputType: AWSOutputType,
-			AWSTableCols:  AWSTableCols,
+			Caller:             *caller,
+			AWSRegions:         internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+			AWSProfile:         profile,
+			Goroutines:         Goroutines,
+			WrapTable:          AWSWrapTable,
+			AWSOutputType:      AWSOutputType,
+			AWSTableCols:       AWSTableCols,
 		}
 
 		endpoints.PrintEndpoints(AWSOutputDirectory, Verbosity)
@@ -2067,12 +2067,11 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		gateways := aws.ApiGwModule{
 			APIGatewayv2Client: apiGatewayv2Client,
 			APIGatewayClient:   apiGatewayClient,
-
-			Caller:     *caller,
-			AWSRegions: internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			AWSProfile: profile,
-			Goroutines: Goroutines,
-			WrapTable:  AWSWrapTable,
+			Caller:             *caller,
+			AWSRegions:         internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+			AWSProfile:         profile,
+			Goroutines:         Goroutines,
+			WrapTable:          AWSWrapTable,
 		}
 
 		gateways.PrintApiGws(AWSOutputDirectory, Verbosity)
@@ -2093,10 +2092,9 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		databases.PrintDatabases(AWSOutputDirectory, Verbosity)
 
 		ecstasks := aws.ECSTasksModule{
-			EC2Client: ec2Client,
-			ECSClient: ecsClient,
-			IAMClient: iamClient,
-
+			EC2Client:           ec2Client,
+			ECSClient:           ecsClient,
+			IAMClient:           iamClient,
 			Caller:              *caller,
 			AWSRegions:          internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
 			AWSProfile:          profile,
@@ -2110,9 +2108,8 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		ecstasks.ECSTasks(AWSOutputDirectory, Verbosity)
 
 		eksCommand := aws.EKSModule{
-			EKSClient: eksClient,
-			IAMClient: iamClient,
-
+			EKSClient:           eksClient,
+			IAMClient:           iamClient,
 			Caller:              *caller,
 			AWSRegions:          internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
 			AWSProfile:          profile,
@@ -2140,11 +2137,10 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("Looking for secrets hidden between the seat cushions."))
 
 		ec2UserData := aws.InstancesModule{
-			EC2Client:  ec2Client,
-			IAMClient:  iamClient,
-			Caller:     *caller,
-			AWSRegions: internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-
+			EC2Client:              ec2Client,
+			IAMClient:              iamClient,
+			Caller:                 *caller,
+			AWSRegions:             internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
 			UserDataAttributesOnly: true,
 			AWSProfile:             profile,
 			Goroutines:             Goroutines,
@@ -2154,7 +2150,6 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		}
 		ec2UserData.Instances(InstancesFilter, AWSOutputDirectory, Verbosity)
 		envsMod := aws.EnvsModule{
-
 			Caller:          *caller,
 			AWSRegions:      internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
 			AWSProfile:      profile,
@@ -2220,14 +2215,13 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		secrets := aws.SecretsModule{
 			SecretsManagerClient: secretsManagerClient,
 			SSMClient:            ssmClient,
-
-			Caller:        *caller,
-			AWSRegions:    internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			AWSProfile:    profile,
-			Goroutines:    Goroutines,
-			WrapTable:     AWSWrapTable,
-			AWSOutputType: AWSOutputType,
-			AWSTableCols:  AWSTableCols,
+			Caller:               *caller,
+			AWSRegions:           internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+			AWSProfile:           profile,
+			Goroutines:           Goroutines,
+			WrapTable:            AWSWrapTable,
+			AWSOutputType:        AWSOutputType,
+			AWSTableCols:         AWSTableCols,
 		}
 		secrets.PrintSecrets(AWSOutputDirectory, Verbosity)
 
@@ -2261,10 +2255,8 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		networkPorts.PrintNetworkPorts(AWSOutputDirectory)
 
 		sqsMod := aws.SQSModule{
-			SQSClient: sqsClient,
-
+			SQSClient:     sqsClient,
 			StorePolicies: StoreSQSAccessPolicies,
-
 			Caller:        *caller,
 			AWSRegions:    internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
 			AWSProfile:    profile,
@@ -2278,20 +2270,7 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		cloudFoxSNSClient := aws.InitCloudFoxSNSClient(*caller, profile, cmd.Root().Version, Goroutines, AWSWrapTable, AWSMFAToken)
 		cloudFoxSNSClient.PrintSNS(AWSOutputDirectory, Verbosity)
 
-		resourceTrustsCommand := aws.ResourceTrustsModule{
-			KMSClient:          kmsClient,
-			Caller:             *caller,
-			AWSProfileProvided: profile,
-			Goroutines:         Goroutines,
-			AWSRegions:         internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			WrapTable:          AWSWrapTable,
-			CloudFoxVersion:    cmd.Root().Version,
-			AWSOutputType:      AWSOutputType,
-			AWSTableCols:       AWSTableCols,
-			AWSMFAToken:        AWSMFAToken,
-			AWSConfig:          AWSConfig,
-		}
-		resourceTrustsCommand.PrintResources(AWSOutputDirectory, Verbosity, ResourceTrustsIncludeKms)
+		runResourceTrustsCommandWithProfile(cmd, args, profile)
 
 		codeBuildCommand := aws.CodeBuildModule{
 			CodeBuildClient:     codeBuildClient,

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -1616,11 +1616,15 @@ func runResourceTrustsCommand(cmd *cobra.Command, args []string) {
 	for _, profile := range AWSProfiles {
 		var AWSConfig = internal.AWSConfigFileLoader(profile, cmd.Root().Version, AWSMFAToken)
 		caller, err := internal.AWSWhoami(profile, cmd.Root().Version, AWSMFAToken)
+		var KMSClient sdk.KMSClientInterface = kms.NewFromConfig(AWSConfig)
+		var APIGatewayClient sdk.APIGatewayClientInterface = apigateway.NewFromConfig(AWSConfig)
+
 		if err != nil {
 			continue
 		}
 		m := aws.ResourceTrustsModule{
-			KMSClient:          kms.NewFromConfig(AWSConfig),
+			KMSClient:          &KMSClient,
+			APIGatewayClient:   &APIGatewayClient,
 			Caller:             *caller,
 			AWSProfileProvided: profile,
 			Goroutines:         Goroutines,


### PR DESCRIPTION
#### Card
https://github.com/BishopFox/cloudfox/issues/98: Adding more Resource-Policy checks for "cloudfox aws resource-trusts"

#### Details
- Add apigateway service to resource trusts command. 
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/ec4cd44e-f3e3-4d57-aeba-2bf38afcd2b7" />

- all-checks command still works
