### PR TITLE
feat: Add opensearch to resource trusts command

### DIFF
--- a/aws/resource-trusts.go
+++ b/aws/resource-trusts.go
@@ -78,10 +78,10 @@ func (m *ResourceTrustsModule) PrintResources(outputDirectory string, verbosity 
 	fmt.Printf("[%s][%s] Enumerating Resources with resource policies for account %s.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileStub), aws.ToString(m.Caller.Account))
 	// if kms feature flag is enabled include kms in the supported services
 	if includeKms {
-		fmt.Printf("[%s][%s] Supported Services: APIGateway, CodeBuild, ECR, EFS, Glue, KMS, Lambda, SecretsManager, S3, SNS, SQS, VpcEndpoint\n",
+		fmt.Printf("[%s][%s] Supported Services: APIGateway, CodeBuild, ECR, EFS, Glue, KMS, Lambda, Opensearch, SecretsManager, S3, SNS, SQS, VpcEndpoint\n",
 			cyan(m.output.CallingModule), cyan(m.AWSProfileStub))
 	} else {
-		fmt.Printf("[%s][%s] Supported Services: APIGateway, CodeBuild, ECR, EFS, Glue, Lambda, SecretsManager, S3, SNS, "+
+		fmt.Printf("[%s][%s] Supported Services: APIGateway, CodeBuild, ECR, EFS, Glue, Lambda, Opensearch, SecretsManager, S3, SNS, "+
 			"SQS (KMS requires --include-kms feature flag), VpcEndpoint\n",
 			cyan(m.output.CallingModule), cyan(m.AWSProfileStub))
 	}

--- a/aws/resource-trusts.go
+++ b/aws/resource-trusts.go
@@ -22,6 +22,7 @@ type ResourceTrustsModule struct {
 	KMSClient        *sdk.KMSClientInterface
 	APIGatewayClient *sdk.APIGatewayClientInterface
 	EC2Client        *sdk.AWSEC2ClientInterface
+	OpenSearchClient *sdk.OpenSearchClientInterface
 
 	// General configuration data
 	Caller             sts.GetCallerIdentityOutput
@@ -321,6 +322,18 @@ func (m *ResourceTrustsModule) executeChecks(r string, wg *sync.WaitGroup, semap
 			m.getVPCEndpointPoliciesPerRegion(r, wg, semaphore, dataReceiver)
 		}
 	}
+
+	if m.OpenSearchClient != nil {
+		res, err = servicemap.IsServiceInRegion("es", r)
+		if err != nil {
+			m.modLog.Error(err)
+		}
+		if res {
+			m.CommandCounter.Total++
+			wg.Add(1)
+			m.getOpenSearchPoliciesPerRegion(r, wg, semaphore, dataReceiver)
+		}
+	}
 }
 
 func (m *ResourceTrustsModule) Receiver(receiver chan Resource2, receiverDone chan bool) {
@@ -356,7 +369,7 @@ func (m *ResourceTrustsModule) getSNSTopicsPerRegion(r string, wg *sync.WaitGrou
 
 	for _, t := range ListTopics {
 		var statementSummaryInEnglish string
-		var isInteresting string = "No"
+		var isInteresting = "No"
 		topic, err := cloudFoxSNSClient.getTopicWithAttributes(aws.ToString(t.TopicArn), r)
 		if err != nil {
 			m.modLog.Error(err.Error())
@@ -366,9 +379,10 @@ func (m *ResourceTrustsModule) getSNSTopicsPerRegion(r string, wg *sync.WaitGrou
 		parsedArn, err := arn.Parse(aws.ToString(t.TopicArn))
 		if err != nil {
 			topic.Name = aws.ToString(t.TopicArn)
+		} else {
+			topic.Name = parsedArn.Resource
+			topic.Region = parsedArn.Region
 		}
-		topic.Name = parsedArn.Resource
-		topic.Region = parsedArn.Region
 
 		// check if topic is public or not
 		if topic.Policy.IsPublic() {
@@ -1107,6 +1121,99 @@ func (m *ResourceTrustsModule) getVPCEndpointPoliciesPerRegion(r string, wg *syn
 				ResourcePolicySummary: statementSummaryInEnglish,
 				Public:                isPublic,
 				Name:                  aws.ToString(vpcEndpoint.VpcEndpointId),
+				Region:                r,
+				Interesting:           isInteresting,
+			}
+		}
+	}
+}
+
+func (m *ResourceTrustsModule) getOpenSearchPoliciesPerRegion(r string, wg *sync.WaitGroup, semaphore chan struct{}, dataReceiver chan Resource2) {
+	defer func() {
+		m.CommandCounter.Executing--
+		m.CommandCounter.Complete++
+		wg.Done()
+	}()
+	semaphore <- struct{}{}
+	defer func() { <-semaphore }()
+
+	openSearchDomains, err := sdk.CachedOpenSearchListDomainNames(*m.OpenSearchClient, aws.ToString(m.Caller.Account), r)
+	if err != nil {
+		sharedLogger.Error(err.Error())
+		return
+	}
+	for _, openSearchDomain := range openSearchDomains {
+		var isPublic string
+		var statementSummaryInEnglish string
+		var isInteresting = "No"
+
+		openSearchDomainConfig, err := sdk.CachedOpenSearchDescribeDomainConfig(*m.OpenSearchClient, aws.ToString(m.Caller.Account), r, aws.ToString(openSearchDomain.DomainName))
+		if err != nil {
+			sharedLogger.Error(err.Error())
+			m.CommandCounter.Error++
+			continue
+		}
+
+		if aws.ToBool(openSearchDomainConfig.AdvancedSecurityOptions.Options.Enabled) {
+			isPublic = "No"
+		} else {
+			isPublic = magenta("Yes")
+			isInteresting = magenta("Yes")
+		}
+
+		openSearchDomainStatus, err := sdk.CachedOpenSearchDescribeDomain(*m.OpenSearchClient, aws.ToString(m.Caller.Account), r, aws.ToString(openSearchDomain.DomainName))
+		if err != nil {
+			sharedLogger.Error(err.Error())
+			m.CommandCounter.Error++
+			continue
+		}
+
+		if openSearchDomainStatus.AccessPolicies != nil && *openSearchDomainStatus.AccessPolicies != "" {
+
+			// remove backslashes from the policy JSON
+			policyJson := strings.ReplaceAll(aws.ToString(openSearchDomainStatus.AccessPolicies), `\"`, `"`)
+
+			openSearchDomainPolicy, err := policy.ParseJSONPolicy([]byte(policyJson))
+			if err != nil {
+				sharedLogger.Error(fmt.Errorf("parsing policy (%s) as JSON: %s", aws.ToString(openSearchDomainStatus.ARN), err))
+				m.CommandCounter.Error++
+				continue
+			}
+
+			if !openSearchDomainPolicy.IsEmpty() {
+				for i, statement := range openSearchDomainPolicy.Statement {
+					prefix := ""
+					if len(openSearchDomainPolicy.Statement) > 1 {
+						prefix = fmt.Sprintf("Statement %d says: ", i)
+						statementSummaryInEnglish = prefix + statement.GetStatementSummaryInEnglish(*m.Caller.Account) + "\n"
+					} else {
+						statementSummaryInEnglish = statement.GetStatementSummaryInEnglish(*m.Caller.Account)
+					}
+
+					statementSummaryInEnglish = strings.TrimSuffix(statementSummaryInEnglish, "\n")
+					if isResourcePolicyInteresting(statementSummaryInEnglish) {
+						//magenta(statementSummaryInEnglish)
+						isInteresting = magenta("Yes")
+					}
+
+					dataReceiver <- Resource2{
+						AccountID:             aws.ToString(m.Caller.Account),
+						ARN:                   aws.ToString(openSearchDomainStatus.ARN),
+						ResourcePolicySummary: statementSummaryInEnglish,
+						Public:                isPublic,
+						Name:                  aws.ToString(openSearchDomain.DomainName),
+						Region:                r,
+						Interesting:           isInteresting,
+					}
+				}
+			}
+		} else {
+			dataReceiver <- Resource2{
+				AccountID:             aws.ToString(m.Caller.Account),
+				ARN:                   aws.ToString(openSearchDomainStatus.ARN),
+				ResourcePolicySummary: statementSummaryInEnglish,
+				Public:                isPublic,
+				Name:                  aws.ToString(openSearchDomain.DomainName),
 				Region:                r,
 				Interesting:           isInteresting,
 			}

--- a/aws/resource-trusts_test.go
+++ b/aws/resource-trusts_test.go
@@ -189,16 +189,13 @@ func TestVpcEndpointResourceTrusts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc.testModule.PrintResources(tc.outputDirectory, tc.verbosity)
+		tc.testModule.PrintResources(tc.outputDirectory, tc.verbosity, false)
 		for index, expectedResource2 := range tc.expectedResult {
 			if expectedResource2.Name != tc.testModule.Resources2[index].Name {
 				t.Fatal("Resource name does not match expected value")
 			}
 			if expectedResource2.ARN != tc.testModule.Resources2[index].ARN {
 				t.Fatal("Resource ARN does not match expected value")
-			}
-			if expectedResource2.Public != tc.testModule.Resources2[index].Public {
-				t.Fatal("Resource Public does not match expected value")
 			}
 		}
 	}

--- a/aws/resource-trusts_test.go
+++ b/aws/resource-trusts_test.go
@@ -197,6 +197,9 @@ func TestVpcEndpointResourceTrusts(t *testing.T) {
 			if expectedResource2.ARN != tc.testModule.Resources2[index].ARN {
 				t.Fatal("Resource ARN does not match expected value")
 			}
+			if expectedResource2.Public != tc.testModule.Resources2[index].Public {
+				t.Fatal("Resource Public does not match expected value")
+			}
 		}
 	}
 }

--- a/aws/sdk/codebuild_mocks.go
+++ b/aws/sdk/codebuild_mocks.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	codeBuildTypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
 )
 
 type MockedCodeBuildClient struct {
@@ -15,6 +16,19 @@ func (m *MockedCodeBuildClient) ListProjects(ctx context.Context, input *codebui
 		Projects: []string{
 			"project1",
 			"project2",
+		},
+	}, nil
+}
+
+func (m *MockedCodeBuildClient) BatchGetProjects(ctx context.Context, input *codebuild.BatchGetProjectsInput, options ...func(*codebuild.Options)) (*codebuild.BatchGetProjectsOutput, error) {
+	return &codebuild.BatchGetProjectsOutput{
+		Projects: []codeBuildTypes.Project{
+			{
+				Name: aws.String("project1"),
+			},
+			{
+				Name: aws.String("project2"),
+			},
 		},
 	}, nil
 }

--- a/aws/sdk/opensearch.go
+++ b/aws/sdk/opensearch.go
@@ -23,7 +23,7 @@ func init() {
 	gob.Register(openSearchTypes.DomainStatus{})
 }
 
-// create CachedOpenSearchListDomainNames function that uses go-cache and pagination
+// CachedOpenSearchListDomainNames function that uses go-cache and pagination
 func CachedOpenSearchListDomainNames(client OpenSearchClientInterface, accountID string, region string) ([]openSearchTypes.DomainInfo, error) {
 	var domains []openSearchTypes.DomainInfo
 	cacheKey := fmt.Sprintf("%s-opensearch-ListDomainNames-%s", accountID, region)
@@ -50,8 +50,11 @@ func CachedOpenSearchListDomainNames(client OpenSearchClientInterface, accountID
 	return domains, nil
 }
 
-// create CachedOpenSearchDescribeDomainConfig function that uses go-cache and pagination and supports region option
+// CachedOpenSearchDescribeDomainConfig function that uses go-cache and pagination and supports region option
 func CachedOpenSearchDescribeDomainConfig(client OpenSearchClientInterface, accountID string, region string, domainName string) (openSearchTypes.DomainConfig, error) {
+
+	fmt.Printf("CachedOpenSearchDescribeDomainConfig: %s %s %s\n", accountID, region, domainName)
+
 	var DomainConfig openSearchTypes.DomainConfig
 	cacheKey := fmt.Sprintf("%s-opensearch-DescribeDomainConfig-%s-%s", accountID, region, domainName)
 	cached, found := internal.Cache.Get(cacheKey)
@@ -78,7 +81,7 @@ func CachedOpenSearchDescribeDomainConfig(client OpenSearchClientInterface, acco
 	return DomainConfig, nil
 }
 
-// create CachedOpenSearchDescribeDomain function that uses go-cache and pagination and supports region option
+// CachedOpenSearchDescribeDomain function that uses go-cache and pagination and supports region option
 func CachedOpenSearchDescribeDomain(client OpenSearchClientInterface, accountID string, region string, domainName string) (openSearchTypes.DomainStatus, error) {
 	var DomainStatus openSearchTypes.DomainStatus
 	cacheKey := fmt.Sprintf("%s-opensearch-DescribeDomain-%s-%s", accountID, region, domainName)

--- a/aws/sdk/opensearch_mocks.go
+++ b/aws/sdk/opensearch_mocks.go
@@ -27,8 +27,8 @@ func (m *MockedOpenSearchClient) ListDomainNames(ctx context.Context, input *ope
 }
 
 func (m *MockedOpenSearchClient) DescribeDomainConfig(ctx context.Context, input *opensearch.DescribeDomainConfigInput, options ...func(*opensearch.Options)) (*opensearch.DescribeDomainConfigOutput, error) {
-	return &opensearch.DescribeDomainConfigOutput{
-		DomainConfig: &openSearchTypes.DomainConfig{
+	domainConfigMap := map[string]*openSearchTypes.DomainConfig{
+		"domain1": {
 			EngineVersion: &openSearchTypes.VersionStatus{
 				Options: aws.String("OpenSearch-1.1"),
 				Status: &openSearchTypes.OptionStatus{
@@ -49,15 +49,63 @@ func (m *MockedOpenSearchClient) DescribeDomainConfig(ctx context.Context, input
 					EnforceHTTPS: aws.Bool(true),
 				},
 			},
+			AdvancedSecurityOptions: &openSearchTypes.AdvancedSecurityOptionsStatus{
+				Options: &openSearchTypes.AdvancedSecurityOptions{
+					Enabled: aws.Bool(true),
+				},
+			},
 		},
+		"domain2": {
+			EngineVersion: &openSearchTypes.VersionStatus{
+				Options: aws.String("OpenSearch-1.1"),
+				Status: &openSearchTypes.OptionStatus{
+					PendingDeletion: aws.Bool(false),
+				},
+			},
+			ClusterConfig: &openSearchTypes.ClusterConfigStatus{
+				Options: &openSearchTypes.ClusterConfig{
+					DedicatedMasterCount:   aws.Int32(3),
+					DedicatedMasterEnabled: aws.Bool(true),
+					InstanceCount:          aws.Int32(3),
+					WarmCount:              aws.Int32(3),
+					WarmEnabled:            aws.Bool(true),
+				},
+			},
+			DomainEndpointOptions: &openSearchTypes.DomainEndpointOptionsStatus{
+				Options: &openSearchTypes.DomainEndpointOptions{
+					EnforceHTTPS: aws.Bool(true),
+				},
+			},
+			AdvancedSecurityOptions: &openSearchTypes.AdvancedSecurityOptionsStatus{
+				Options: &openSearchTypes.AdvancedSecurityOptions{
+					Enabled: aws.Bool(false),
+				},
+			},
+		},
+	}
+
+	return &opensearch.DescribeDomainConfigOutput{
+		DomainConfig: domainConfigMap[*input.DomainName],
 	}, nil
 }
 
 func (m *MockedOpenSearchClient) DescribeDomain(ctx context.Context, input *opensearch.DescribeDomainInput, options ...func(*opensearch.Options)) (*opensearch.DescribeDomainOutput, error) {
-	return &opensearch.DescribeDomainOutput{
-		DomainStatus: &openSearchTypes.DomainStatus{
-			DomainName: aws.String("domain1"),
-			Endpoint:   aws.String("https://domain1.us-east-1.es.amazonaws.com"),
+	domainStatusMap := map[string]*openSearchTypes.DomainStatus{
+		"domain1": {
+			DomainName:     aws.String("domain1"),
+			Endpoint:       aws.String("https://domain1.us-east-1.es.amazonaws.com"),
+			ARN:            aws.String("arn:aws:es:us-east-1:123456789012:domain/domain1"),
+			AccessPolicies: aws.String(`{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"es:ESHttpGet\",\"es:ESHttpHead\",\"es:ESHttpPost\"],\"Resource\":\"*\",\"Condition\":{\"IpAddress\":{\"aws:SourceIp\":\"192.168.1.100/32\"}}}]}`),
 		},
+		"domain2": {
+			DomainName:     aws.String("domain2"),
+			Endpoint:       aws.String("https://domain2.us-east-1.es.amazonaws.com"),
+			ARN:            aws.String("arn:aws:es:us-east-1:123456789012:domain/domain2"),
+			AccessPolicies: aws.String(`{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"es:ESHttpGet\",\"es:ESHttpHead\",\"es:ESHttpPost\"],\"Resource\":\"*\"}]}`),
+		},
+	}
+
+	return &opensearch.DescribeDomainOutput{
+		DomainStatus: domainStatusMap[*input.DomainName],
 	}, nil
 }

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -1630,9 +1630,10 @@ func runResourceTrustsCommandWithProfile(cmd *cobra.Command, args []string, prof
 		return
 	}
 	m := aws.ResourceTrustsModule{
-		KMSClient:          &KMSClient,
-		APIGatewayClient:   &APIGatewayClient,
-		EC2Client:          &EC2Client,
+		KMSClient:        &KMSClient,
+		APIGatewayClient: &APIGatewayClient,
+		EC2Client:        &EC2Client,
+
 		Caller:             *caller,
 		AWSProfileProvided: profile,
 		Goroutines:         Goroutines,

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -569,7 +569,7 @@ func awsPreRun(cmd *cobra.Command, args []string) {
 			cacheDirectory := filepath.Join(AWSOutputDirectory, "cached-data", "aws", ptr.ToString(caller.Account))
 			err = internal.LoadCacheFromGobFiles(cacheDirectory)
 			if err != nil {
-				if err == internal.ErrDirectoryDoesNotExist {
+				if errors.Is(err, internal.ErrDirectoryDoesNotExist) {
 					fmt.Printf("[%s][%s] No cache directory for %s. Skipping loading cached data.\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), cyan(profile), ptr.ToString(caller.Account))
 				} else {
 					fmt.Printf("[%s][%s] No cache data for %s. Error: %v\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), cyan(profile), ptr.ToString(caller.Account), err)
@@ -921,7 +921,6 @@ func runEnvsCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 		m := aws.EnvsModule{
-
 			Caller:        *caller,
 			AWSRegions:    internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
 			AWSProfile:    profile,
@@ -1201,7 +1200,7 @@ func runCapeCommand(cmd *cobra.Command, args []string) {
 			graph.EdgeAttribute(edge.ShortReason, edge.Reason),
 		)
 		if err != nil {
-			if err == graph.ErrEdgeAlreadyExists {
+			if errors.Is(err, graph.ErrEdgeAlreadyExists) {
 				// update theedge by copying the existing graph.Edge with attributes and add the new attributes
 				//fmt.Println("Edge already exists")
 
@@ -1625,6 +1624,7 @@ func runResourceTrustsCommandWithProfile(cmd *cobra.Command, args []string, prof
 	var KMSClient sdk.KMSClientInterface = kms.NewFromConfig(AWSConfig)
 	var APIGatewayClient sdk.APIGatewayClientInterface = apigateway.NewFromConfig(AWSConfig)
 	var EC2Client sdk.AWSEC2ClientInterface = ec2.NewFromConfig(AWSConfig)
+	var OpenSearchClient sdk.OpenSearchClientInterface = opensearch.NewFromConfig(AWSConfig)
 
 	if err != nil {
 		return
@@ -1633,6 +1633,7 @@ func runResourceTrustsCommandWithProfile(cmd *cobra.Command, args []string, prof
 		KMSClient:        &KMSClient,
 		APIGatewayClient: &APIGatewayClient,
 		EC2Client:        &EC2Client,
+		OpenSearchClient: &OpenSearchClient,
 
 		Caller:             *caller,
 		AWSProfileProvided: profile,

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -4,10 +4,11 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 
 	"github.com/BishopFox/cloudfox/aws"
 	"github.com/BishopFox/cloudfox/aws/sdk"

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.56.3
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.40.3
 	github.com/aws/aws-sdk-go-v2/service/mq v1.25.3
-	github.com/aws/aws-sdk-go-v2/service/opensearch v1.39.2
+	github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2
 	github.com/aws/aws-sdk-go-v2/service/ram v1.27.3
 	github.com/aws/aws-sdk-go-v2/service/rds v1.82.0

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.56.3
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.40.3
 	github.com/aws/aws-sdk-go-v2/service/mq v1.25.3
-	github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1
+	github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.3
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2
 	github.com/aws/aws-sdk-go-v2/service/ram v1.27.3
 	github.com/aws/aws-sdk-go-v2/service/rds v1.82.0

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/aws/aws-sdk-go-v2/service/lightsail v1.40.3 h1:dy4sbyGy7BS4c0KaPZwg1P
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.40.3/go.mod h1:EMgqMhof+RuaYvQavxKC0ZWvP7yB4B4NJhP+dbm13u0=
 github.com/aws/aws-sdk-go-v2/service/mq v1.25.3 h1:SyRcb9GRPcoNKCuLnpj1qGIr/8stnVIf4DsuRhXIzEA=
 github.com/aws/aws-sdk-go-v2/service/mq v1.25.3/go.mod h1:Xu8nT/Yj64z5Gj1ebVB3drPEIBsPNDoFhx2xZDrdGlc=
-github.com/aws/aws-sdk-go-v2/service/opensearch v1.39.2 h1:px8DLC+DOd2fCLnMm6XlyeLU/9B0dXZWzYXzHSKAzZY=
-github.com/aws/aws-sdk-go-v2/service/opensearch v1.39.2/go.mod h1:91AFffUmnw/bumAEE6Sf1yWgW3YdsjexH5c6hePGwSQ=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1 h1:PJPORR5Y+Vdvz+JzR7P5BA/i+lHpGQOhtpuJyvDdK00=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1/go.mod h1:51rUy2+lDiOQVlekScV044he709HMMhCdUDHqSBojgg=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2 h1:+tGF0JH2u4HwneqNFAKFHqENwfpBweKj67+LbwTKpqE=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2/go.mod h1:6wxO8s5wMumyNRsOgOgcIvqvF8rIf8Cj7Khhn/bFI0c=
 github.com/aws/aws-sdk-go-v2/service/ram v1.27.3 h1:MoQ0up3IiE2fl0+qySx3Lb0swK6G6ESQ4S3w3WfJZ48=

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/aws/aws-sdk-go-v2/service/mq v1.25.3 h1:SyRcb9GRPcoNKCuLnpj1qGIr/8stn
 github.com/aws/aws-sdk-go-v2/service/mq v1.25.3/go.mod h1:Xu8nT/Yj64z5Gj1ebVB3drPEIBsPNDoFhx2xZDrdGlc=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1 h1:PJPORR5Y+Vdvz+JzR7P5BA/i+lHpGQOhtpuJyvDdK00=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1/go.mod h1:51rUy2+lDiOQVlekScV044he709HMMhCdUDHqSBojgg=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.3 h1:vWClqL1dTCuPtWkaGDW7Y6P9ocqHtfFrjlkWYARm1qI=
+github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.3/go.mod h1:51rUy2+lDiOQVlekScV044he709HMMhCdUDHqSBojgg=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2 h1:+tGF0JH2u4HwneqNFAKFHqENwfpBweKj67+LbwTKpqE=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2/go.mod h1:6wxO8s5wMumyNRsOgOgcIvqvF8rIf8Cj7Khhn/bFI0c=
 github.com/aws/aws-sdk-go-v2/service/ram v1.27.3 h1:MoQ0up3IiE2fl0+qySx3Lb0swK6G6ESQ4S3w3WfJZ48=

--- a/internal/aws/policy/policy.go
+++ b/internal/aws/policy/policy.go
@@ -22,7 +22,7 @@ func ParseJSONPolicy(data []byte) (Policy, error) {
 	return p, nil
 }
 
-// IsNull returns true iff the Policy is empty
+// IsEmpty returns true if the Policy is empty
 // you cannot do a comparison like this: `p == Policy{}' since we use custom types in the struct`
 func (p *Policy) IsEmpty() bool {
 	out := true
@@ -37,7 +37,7 @@ func (p *Policy) IsEmpty() bool {
 	return out
 }
 
-// true iff there is at least one statement with principal * and no conditions
+// IsPublic true if there is at least one statement with principal * and no conditions
 func (p *Policy) IsPublic() bool {
 	for _, s := range p.Statement {
 		if s.IsAllow() && s.Principal.IsPublic() && s.Condition.IsEmpty() {
@@ -48,7 +48,7 @@ func (p *Policy) IsPublic() bool {
 	return false
 }
 
-// true iff there is at least one statement with principal * with conditions that do not scope access down to AWS accounts or organizations
+// IsConditionallyPublic true if there is at least one statement with principal * with conditions that do not scope access down to AWS accounts or organizations
 func (p *Policy) IsConditionallyPublic() bool {
 	for _, s := range p.Statement {
 		if s.IsAllow() && s.Principal.IsPublic() && !s.Condition.IsScopedOnAccountOrOrganization() && !s.Condition.IsEmpty() {
@@ -99,8 +99,8 @@ func composePattern(stringToTransform string) *regexp.Regexp {
 	return pattern
 }
 
-// source: https://github.com/nccgroup/PMapper/blob/master/principalmapper/querying/local_policy_simulation.py
 // MatchesAfterExpansion checks the stringToCheck against stringToCheckAgainst.
+// source: https://github.com/nccgroup/PMapper/blob/master/principalmapper/querying/local_policy_simulation.py
 func MatchesAfterExpansion(stringFromPolicyToCheck, stringToCheckAgainst string) bool {
 	// Transform the stringToCheckAgainst into a regex pattern
 	pattern := composePattern(stringToCheckAgainst)
@@ -108,9 +108,6 @@ func MatchesAfterExpansion(stringFromPolicyToCheck, stringToCheckAgainst string)
 	// Check if the pattern matches stringToCheck
 	return pattern.MatchString(stringFromPolicyToCheck)
 }
-
-
-
 
 func (p *Policy) DoesPolicyHaveMatchingStatement(effect string, actionToCheck string, resourceToCheck string) bool {
 


### PR DESCRIPTION
#### Card
https://github.com/BishopFox/cloudfox/issues/98: Adding more Resource-Policy checks for "cloudfox aws resource-trusts"

#### Details
- Add OpenSearch service to resource trusts command. 
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/0a68b5b0-5e06-4b48-b62b-aea30664baea" />

- all-checks command still works
